### PR TITLE
implement __contains__ so the 'in' operator works

### DIFF
--- a/jsonstore/__init__.py
+++ b/jsonstore/__init__.py
@@ -159,3 +159,6 @@ class JsonStore(object):
         path, _, key = name.rpartition('.')
         obj = self.__get_obj(path)
         del obj[key]
+
+    def __contains__(self, key):
+        return key in self._data

--- a/jsonstore/tests.py
+++ b/jsonstore/tests.py
@@ -102,6 +102,13 @@ class Tests(unittest.TestCase):
             self.assertEqual(getattr(self.store, name), value)
             self.assertEqual(self.store[name], value)
 
+    def test_has_values(self):
+        for name, value in self.TEST_DATA:
+            self.store[name] = value
+            self.assertTrue(name in self.store)
+
+        self.assertFalse('foo' in self.store)
+
     def test_assign_cycle(self):
         test_list = []
         test_dict = {}


### PR DESCRIPTION
Using the 'in' operator

> if 'variable' in data:

throws an error:

> AttributeError: 'int' object has no attribute 'split'    

This pull request fixes that by implementing the \_\_contains__ method.