### PR TITLE
Fixed FIleExistsError in the _save method

### DIFF
--- a/jsonstore.py
+++ b/jsonstore.py
@@ -53,6 +53,7 @@ class JsonStore(object):
         with open(temp, "wb") as store:
             output = json.dumps(self._data, indent=self._indent)
             store.write(output.encode("utf-8"))
+        os.remove(self._path)
         os.rename(temp, self._path)
 
     def __init__(self, path, indent=2, auto_commit=True):

--- a/jsonstore.py
+++ b/jsonstore.py
@@ -53,8 +53,14 @@ class JsonStore(object):
         with open(temp, "wb") as store:
             output = json.dumps(self._data, indent=self._indent)
             store.write(output.encode("utf-8"))
-        os.remove(self._path)
-        os.rename(temp, self._path)
+        
+        if sys.version_info >= (3, 3):
+            os.replace(temp, self._path)
+        elif os.name == "windows":
+            os.remove(self._path)
+            os.rename(temp, self._path)
+        else:
+            os.rename(temp, self._path)
 
     def __init__(self, path, indent=2, auto_commit=True):
         self.__dict__.update(


### PR DESCRIPTION
There was an error occuring when calling the `_save` method.

```
FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'C:\\Users\\jakub\\AppData\\Local\\Temp\\tmphz6dzu_7~' -> 'C:\\Users\\jakub\\AppData\\Local\\Temp\\tmphz6dzu_7'
```