### PR TITLE
Add Codecov badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Build Status| |PyPi Package|
+|PyPI| |Build Status| |Coverage Report|
 
 jsonstore
 =========
@@ -110,5 +110,7 @@ file until all of the transactions have been closed.
 
 .. |Build Status| image:: https://github.com/Code0x58/python-jsonstore/actions/workflows/ci.yml/badge.svg
    :target: https://github.com/Code0x58/python-jsonstore/actions/workflows/ci.yml
-.. |PyPi Package| image:: https://badge.fury.io/py/python-jsonstore.svg
+.. |PyPI| image:: https://img.shields.io/pypi/v/python-jsonstore.svg
    :target: https://pypi.org/project/python-jsonstore/
+.. |Coverage Report| image:: https://codecov.io/gh/Code0x58/python-jsonstore/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/Code0x58/python-jsonstore


### PR DESCRIPTION
## Summary
- add a Codecov coverage badge next to the PyPI and CI badges in the README so it matches python-stripzip's ordering

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a06ae03c48322b0d41849e46b0758)